### PR TITLE
Flag for keeping user logged in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ packages/components/.DS_Store
 packages/components/Thumbs.db
 packages/components/UserInterfaceState.xcuserstate
 packages/components/.env
+.aider*
+.env

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You can set these attributes to the `script` tag to customize the behavior:
 - `data-start-screen` - screen shown by default (banner click, window.nostr.* call), options: `welcome`, `welcome-login`, `welcome-signup`, `signup`, `local-signup`, `login`, `otp`, `connect`, `login-bunker-url`, `login-read-only`, `connection-string`, `switch-account`, `import`
 - `data-signup-relays` - comma-separated list of relays where nip65 event will be published on local signup
 - `data-outbox-relays` - comma-separated list of relays that will be added to nip65 event on local signup
+- `data-skip-if-logged-in` - if "true", won't show login popup if user is already logged in
 
 Example:
 ```
@@ -140,6 +141,7 @@ Options:
 - `darkMode` - same as `data-dark-mode` above
 - `noBanner` - same as `data-no-banner` above
 - `isSignInWithExtension` - `true` to bring the *Sign in with exception* button into main list of options, `false` to hide to the *Advanced*, default will behave as `true` if extension is detected.
+- `skipIfLoggedIn` - if true, won't show login popup if user is already logged in
 
 ## OTP login
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -38,6 +38,7 @@ export class NostrLoginInitializer {
         return this.launch();
       },
       wait: cb => this.processManager.wait(cb),
+      skipIfLoggedIn: this.params.optionsModal.skipIfLoggedIn,
     };
 
     this.nostr = new Nostr(nostrApi);

--- a/packages/auth/src/modules/Nostr.ts
+++ b/packages/auth/src/modules/Nostr.ts
@@ -18,6 +18,7 @@ export interface NostrObjectParams {
   launch(): Promise<void>;
   getSigner(): Signer;
   wait<T>(cb: () => Promise<T>): Promise<T>;
+  skipIfLoggedIn?: boolean;
 }
 
 class Nostr {
@@ -51,14 +52,19 @@ class Nostr {
     await this.#params.waitReady();
 
     // authed?
-    if (this.#params.getUserInfo()) return;
+    const userInfo = this.#params.getUserInfo();
+    if (userInfo) return;
 
-    // launch auth flow
-    await this.#params.launch();
+    // launch auth flow if not configured to skip
+    if (!this.#params.skipIfLoggedIn) {
+      await this.#params.launch();
 
-    // give up
-    if (!this.#params.getUserInfo()) {
-      throw new Error('Rejected by user');
+      // give up
+      if (!this.#params.getUserInfo()) {
+        throw new Error('Rejected by user');
+      }
+    } else {
+      throw new Error('Not logged in');
     }
   }
 

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -63,6 +63,9 @@ export interface NostrLoginOptions {
 
   // dev mode
   dev?: boolean;
+
+  // skip showing login popup if user is already logged in
+  skipIfLoggedIn?: boolean;
 }
 
 export interface IBanner {


### PR DESCRIPTION
In some apps the user want to be 'remebered' so they don't have to go through the login screen every time they return a page on the app. In particular any app which isn't a single page web app, will trigger the user to login / request a user profile every page they load. 

This gives an option to allow nostr-login to have 'remember me' like functionality where every page doesn't require the user to reconfirm they're logged in. 